### PR TITLE
[INFRA] Terraform VPC/Subnet/Security Group 구성

### DIFF
--- a/infra/terraform/environments/dev/.terraform.lock.hcl
+++ b/infra/terraform/environments/dev/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "vpc" {
+  source  = "../../modules/vpc"
+  project = var.project
+  env     = var.env
+}
+
+module "security_group" {
+  source  = "../../modules/security-group"
+  project = var.project
+  env     = var.env
+  vpc_id  = module.vpc.vpc_id
+  my_ip   = var.my_ip
+}

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -1,0 +1,19 @@
+variable "aws_region" {
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "project" {
+  type        = string
+  default     = "disasterkok"
+}
+
+variable "env" {
+  type        = string
+  default     = "dev"
+}
+
+variable "my_ip" {
+  type        = string
+  description = "Your IP for SSH access"
+}

--- a/infra/terraform/modules/security-group/main.tf
+++ b/infra/terraform/modules/security-group/main.tf
@@ -1,0 +1,50 @@
+resource "aws_security_group" "k3s" {
+  name        = "${var.project}-${var.env}-k3s-sg"
+  description = "Security group for k3s node"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.my_ip]
+  }
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "k3s API server"
+    from_port   = 6443
+    to_port     = 6443
+    protocol    = "tcp"
+    cidr_blocks = [var.my_ip]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name    = "${var.project}-${var.env}-k3s-sg"
+    Project = var.project
+    Env     = var.env
+  }
+}

--- a/infra/terraform/modules/security-group/outputs.tf
+++ b/infra/terraform/modules/security-group/outputs.tf
@@ -1,0 +1,3 @@
+output "k3s_sg_id" {
+    value = aws_security_group.k3s.id
+  }

--- a/infra/terraform/modules/security-group/variables.tf
+++ b/infra/terraform/modules/security-group/variables.tf
@@ -1,0 +1,16 @@
+variable "project" {
+  type = string
+}
+
+variable "env" {
+  type = string
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "my_ip" {
+  description = "Your IP for SSH access (e.g. 1.2.3.4/32)"
+  type        = string
+}

--- a/infra/terraform/modules/vpc/main.tf
+++ b/infra/terraform/modules/vpc/main.tf
@@ -1,0 +1,54 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name    = "${var.project}-${var.env}-vpc"
+    Project = var.project
+    Env     = var.env
+  }
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidr
+  availability_zone       = var.az
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name    = "${var.project}-${var.env}-public-subnet"
+    Project = var.project
+    Env     = var.env
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name    = "${var.project}-${var.env}-igw"
+    Project = var.project
+    Env     = var.env
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name    = "${var.project}-${var.env}-public-rt"
+    Project = var.project
+    Env     = var.env
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}

--- a/infra/terraform/modules/vpc/outputs.tf
+++ b/infra/terraform/modules/vpc/outputs.tf
@@ -1,0 +1,7 @@
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "public_subnet_id" {
+  value = aws_subnet.public.id
+}

--- a/infra/terraform/modules/vpc/variables.tf
+++ b/infra/terraform/modules/vpc/variables.tf
@@ -1,0 +1,27 @@
+variable "project" {
+  description = "Project name"
+  type        = string
+}
+
+variable "env" {
+  description = "Environment (dev/prod)"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnet_cidr" {
+  description = "CIDR block for public subnet"
+  type        = string
+  default     = "10.0.1.0/24"
+}
+
+variable "az" {
+  description = "Availability zone"
+  type        = string
+  default     = "ap-northeast-2a"
+}


### PR DESCRIPTION
## 📊 요약

AWS 네트워크 기반 리소스를 Terraform으로 코드화했습니다. k3s 클러스터를 올릴 VPC, 퍼블릭 서브넷, 인터넷 게이트웨이, 라우팅 테이블, EC2용 Security Group을 modules/environments 구조로 분리해 재사용 가능하게 작성했습니다.

## 🚨 Breaking Change?
- [ ] 있음
- [x] 없음

## 🧾 PR 타입

- [x] ✨ 기능
- [ ] 🐛 버그
- [ ] ♻️ 리팩터
- [x] 🔧 기타(빌드·CI·문서)

## ✅ 체크리스트

- [x] CI 통과 (lint, type, test)
- [ ] 테스트 코드 추가·수정
- [ ] 문서/주석 업데이트
- [x] 개인정보 / 민감정보 제거 (terraform.tfvars는 .gitignore 처리)

## 📚 상세

### 💬 추가 / 변경된 부분

**디렉토리 구조**
```
infra/terraform/
├── modules/
│   ├── vpc/           # VPC, Subnet, IGW, Route Table
│   └── security-group/ # k3s 노드용 SG
└── environments/
    └── dev/           # provider + module 조합
```

**생성 리소스 (terraform plan 기준)**
- `aws_vpc` — 10.0.0.0/16, DNS 지원 활성화
- `aws_subnet` — 퍼블릭 서브넷 (ap-northeast-2a)
- `aws_internet_gateway` — 퍼블릭 트래픽 라우팅
- `aws_route_table` + `aws_route_table_association`
- `aws_security_group` — SSH/HTTP/HTTPS/k3s API(6443), SSH·k3s는 my_ip 제한

**설계 결정**
- modules/environments 분리: 동일 모듈을 dev/prod 각각 다른 변수로 호출 가능
- my_ip 변수로 SSH/6443 포트 제한: 최소 접근 범위 원칙 적용
- `terraform.tfvars`는 gitignore 처리 (IP 등 환경별 실제값 포함)

### 📣 리뷰 노트

`terraform plan` 검증 방법:
```bash
cd infra/terraform/environments/dev
cp terraform.tfvars.example terraform.tfvars  # my_ip 입력
terraform init
terraform plan
# Plan: 6 to add, 0 to change, 0 to destroy
```

## 🔗 관련 이슈

Closes #7 