### PR TITLE
[INFRA] EC2 인스턴스 및 IAM Role/Instance Profile Terraform 모듈 작성

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,5 +1,5 @@
 name: "🔧 Chore"
-description: "빌드, 의존성, 문서 등 잡무"
+description: "빌드, 설정, 인프라, 의존성, 문서 등 잡무"
 title: "[CHORE] "
 labels: ["chore", "sp001"]
 body:
@@ -7,12 +7,29 @@ body:
     id: summary
     attributes:
       label: 작업 요약
+      placeholder: 한 줄로 작업 목적 기술
+    validations:
+      required: true
   - type: textarea
     id: details
     attributes:
       label: 세부 내용
+      placeholder: |
+        - 작성할 파일 목록
+        - 포함할 리소스 또는 설정 항목
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: 완료 기준
+      placeholder: |
+        - terraform plan 오류 없이 통과
+        - 해당 리소스가 plan 결과에 포함됨
+    validations:
+      required: true
   - type: textarea
     id: impact
     attributes:
       label: 영향 범위
-      placeholder: 빌드 시간, 패키지 크기 등
+      placeholder: 빌드 시간, 이미지 크기, 배포 방식 등

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -26,3 +26,19 @@ module "security_group" {
   vpc_id  = module.vpc.vpc_id
   my_ip   = var.my_ip
 }
+
+module "iam" {
+  source  = "../../modules/iam"
+  project = var.project
+  env     = var.env
+}
+
+module "ec2" {
+  source                = "../../modules/ec2"
+  project               = var.project
+  env                   = var.env
+  subnet_id             = module.vpc.public_subnet_id
+  security_group_id     = module.security_group.k3s_sg_id
+  instance_profile_name = module.iam.instance_profile_name
+  key_name              = var.key_name
+}

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -1,19 +1,24 @@
 variable "aws_region" {
-  type        = string
-  default     = "ap-northeast-2"
+  type    = string
+  default = "ap-northeast-2"
 }
 
 variable "project" {
-  type        = string
-  default     = "disasterkok"
+  type    = string
+  default = "disasterkok"
 }
 
 variable "env" {
-  type        = string
-  default     = "dev"
+  type    = string
+  default = "dev"
 }
 
 variable "my_ip" {
   type        = string
   description = "Your IP for SSH access"
+}
+
+variable "key_name" {
+  type        = string
+  description = "EC2 Key Pair 이름"
 }

--- a/infra/terraform/modules/ec2/main.tf
+++ b/infra/terraform/modules/ec2/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.0.0" # Ensure that the Terraform version is 1.0.0 or higher
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws" # Specify the source of the AWS provider
+      version = "~> 4.0"        # Use a version of the AWS provider that is compatible with version
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1" # Set the AWS region to US East (N. Virginia)
+}
+
+resource "aws_instance" "aws_example" {
+  tags = {
+    Name = "ExampleInstance" # Tag the instance with a Name tag for easier identification
+  }
+}

--- a/infra/terraform/modules/ec2/main.tf
+++ b/infra/terraform/modules/ec2/main.tf
@@ -1,20 +1,29 @@
-terraform {
-  required_version = ">= 1.0.0" # Ensure that the Terraform version is 1.0.0 or higher
+data "aws_ami" "al2023" {
+  most_recent = true
+  owners      = ["amazon"]
 
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws" # Specify the source of the AWS provider
-      version = "~> 4.0"        # Use a version of the AWS provider that is compatible with version
-    }
+  filter {
+    name   = "name"
+    values = ["al2023-ami-2023.*-x86_64"]
+  }
+
+  filter {
+    name   = "state"
+    values = ["available"]
   }
 }
 
-provider "aws" {
-  region = "us-east-1" # Set the AWS region to US East (N. Virginia)
-}
+resource "aws_instance" "main" {
+  ami                    = data.aws_ami.al2023.id
+  instance_type          = var.instance_type
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = [var.security_group_id]
+  iam_instance_profile   = var.instance_profile_name
+  key_name               = var.key_name
 
-resource "aws_instance" "aws_example" {
   tags = {
-    Name = "ExampleInstance" # Tag the instance with a Name tag for easier identification
+    Name    = "${var.project}-${var.env}-node"
+    Project = var.project
+    Env     = var.env
   }
 }

--- a/infra/terraform/modules/ec2/outputs.tf
+++ b/infra/terraform/modules/ec2/outputs.tf
@@ -1,0 +1,4 @@
+output "instance_public_ip" {
+  value       = ""                                          # The actual value to be outputted
+  description = "The public IP address of the EC2 instance" # Description of what this output represents
+}

--- a/infra/terraform/modules/ec2/outputs.tf
+++ b/infra/terraform/modules/ec2/outputs.tf
@@ -1,4 +1,7 @@
-output "instance_public_ip" {
-  value       = ""                                          # The actual value to be outputted
-  description = "The public IP address of the EC2 instance" # Description of what this output represents
-}
+  output "instance_id" {
+    value = aws_instance.main.id
+  }
+
+  output "public_ip" {
+    value = aws_instance.main.public_ip
+  }

--- a/infra/terraform/modules/ec2/variables.tf
+++ b/infra/terraform/modules/ec2/variables.tf
@@ -1,0 +1,5 @@
+variable "instance_type" {
+  type        = string                     # The type of the variable, in this case a string
+  default     = "t2.micro"                 # Default value for the variable
+  description = "The type of EC2 instance" # Description of what this variable represents
+}

--- a/infra/terraform/modules/ec2/variables.tf
+++ b/infra/terraform/modules/ec2/variables.tf
@@ -1,5 +1,28 @@
+variable "project" {
+  type = string
+}
+
+variable "env" {
+  type = string
+}
+
+variable "subnet_id" {
+  type = string
+}
+
+variable "security_group_id" {
+  type = string
+}
+
+variable "instance_profile_name" {
+  type = string
+}
+
+variable "key_name" {
+  type = string
+}
+
 variable "instance_type" {
-  type        = string                     # The type of the variable, in this case a string
-  default     = "t2.micro"                 # Default value for the variable
-  description = "The type of EC2 instance" # Description of what this variable represents
+  type    = string
+  default = "t3.small"
 }

--- a/infra/terraform/modules/iam/main.tf
+++ b/infra/terraform/modules/iam/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.0.0" # Ensure that the Terraform version is 1.0.0 or higher
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws" # Specify the source of the AWS provider
+      version = "~> 4.0"        # Use a version of the AWS provider that is compatible with version
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1" # Set the AWS region to US East (N. Virginia)
+}
+
+resource "aws_instance" "aws_example" {
+  tags = {
+    Name = "ExampleInstance" # Tag the instance with a Name tag for easier identification
+  }
+}

--- a/infra/terraform/modules/iam/main.tf
+++ b/infra/terraform/modules/iam/main.tf
@@ -1,20 +1,25 @@
-terraform {
-  required_version = ">= 1.0.0" # Ensure that the Terraform version is 1.0.0 or higher
+# EC2가 AWS 서비스를 assume 할 수 있도록 허용하는 Trust Policy
+resource "aws_iam_role" "ec2" {
+  name = "${var.project}-${var.env}-ec2-role"
 
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws" # Specify the source of the AWS provider
-      version = "~> 4.0"        # Use a version of the AWS provider that is compatible with version
-    }
-  }
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect    = "Allow",
+      Principal = { Service = "ec2.amazonaws.com" },
+      Action    = "sts:AssumeRole"
+    }]
+  })
 }
 
-provider "aws" {
-  region = "us-east-1" # Set the AWS region to US East (N. Virginia)
+# ECR에서 이미지를 pull 할 수 있는 권한 부여
+resource "aws_iam_role_policy_attachment" "ecr_read" {
+  role = aws_iam_role.ec2.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
 }
 
-resource "aws_instance" "aws_example" {
-  tags = {
-    Name = "ExampleInstance" # Tag the instance with a Name tag for easier identification
-  }
+# EC2에 IAM Role을 연결하기 위한 Instance Profile
+resource "aws_iam_instance_profile" "ec2" {
+  name = "${var.project}-${var.env}-ec2-profile"
+  role = aws_iam_role.ec2.name
 }

--- a/infra/terraform/modules/iam/outputs.tf
+++ b/infra/terraform/modules/iam/outputs.tf
@@ -1,0 +1,4 @@
+output "instance_public_ip" {
+  value       = ""                                          # The actual value to be outputted
+  description = "The public IP address of the EC2 instance" # Description of what this output represents
+}

--- a/infra/terraform/modules/iam/outputs.tf
+++ b/infra/terraform/modules/iam/outputs.tf
@@ -1,4 +1,3 @@
-output "instance_public_ip" {
-  value       = ""                                          # The actual value to be outputted
-  description = "The public IP address of the EC2 instance" # Description of what this output represents
+output "instance_profile_name" {
+  value       = aws_iam_instance_profile.ec2.name
 }

--- a/infra/terraform/modules/iam/variables.tf
+++ b/infra/terraform/modules/iam/variables.tf
@@ -1,0 +1,5 @@
+variable "instance_type" {
+  type        = string                     # The type of the variable, in this case a string
+  default     = "t2.micro"                 # Default value for the variable
+  description = "The type of EC2 instance" # Description of what this variable represents
+}

--- a/infra/terraform/modules/iam/variables.tf
+++ b/infra/terraform/modules/iam/variables.tf
@@ -1,5 +1,7 @@
-variable "instance_type" {
-  type        = string                     # The type of the variable, in this case a string
-  default     = "t2.micro"                 # Default value for the variable
-  description = "The type of EC2 instance" # Description of what this variable represents
+variable "project" {
+  type        = string
+}
+
+variable "env" {
+  type        = string
 }


### PR DESCRIPTION
## 📊 요약

EC2 인스턴스를 배포하기 위한 IAM Role, Instance Profile, EC2 모듈을 Terraform으로 코드화했습니다.
ECR 이미지 Pull 권한을 가진 IAM Role을 EC2에 연결해 컨테이너 기반 배포 기반을 마련했습니다.

## 🚨 Breaking Change?

- [ ] 있음
- [x] 없음

## 🧾 PR 타입

- [ ] ✨ 기능
- [ ] 🐛 버그
- [ ] ♻️ 리팩터
- [x] 🔧 기타(빌드·CI·문서)

## ✅ 체크리스트

- [x] CI 통과 (lint, type, test)
- [ ] 테스트 코드 추가·수정
- [ ] 문서/주석 업데이트
- [x] 개인정보 / 민감정보 제거

## 📚 상세

### 💬 추가 / 변경된 부분

**추가된 모듈:**
- `modules/iam/` — IAM Role + `AmazonEC2ContainerRegistryReadOnly` 정책 연결 + Instance Profile
- `modules/ec2/` — Amazon Linux 2023 AMI data source, EC2 인스턴스 생성
- `environments/dev/main.tf` — iam, ec2 모듈 호출 추가

**기타:**
- `chore.yml` 이슈 템플릿에 완료 기준 필드 추가

### 📣 리뷰 노트

- AMI는 `data "aws_ami"` data source로 조회 (리전 독립적, 크로스 플랫폼 호환)
- IAM은 `aws_iam_role_policy_attachment` 사용 (`aws_iam_policy_attachment`는 정책 독점 부작용으로 배제)
- `terraform plan` 기준 신규 리소스: `aws_iam_role`, `aws_iam_role_policy_attachment`, `aws_iam_instance_profile`, `aws_instance` (4 to add)

## 🔗 관련 이슈

Closes #9