### PR TITLE
[INFRA] ECR 리포지토리 Terraform 모듈 작성

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -42,3 +42,9 @@ module "ec2" {
   instance_profile_name = module.iam.instance_profile_name
   key_name              = var.key_name
 }
+
+module "ecr" {
+  source = "../../modules/ecr"
+  project = var.project
+  env = var.env
+}

--- a/infra/terraform/modules/ecr/main.tf
+++ b/infra/terraform/modules/ecr/main.tf
@@ -1,0 +1,34 @@
+resource "aws_ecr_repository" "main" {
+  name                 = "${var.project}-${var.env}"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Project = var.project
+    Env     = var.env
+  }
+}
+
+# 이미지를 최대 10개만 유지 (오랜된 것 부터 삭제)
+resource "aws_ecr_lifecycle_policy" "main" {
+  repository = aws_ecr_repository.main.name
+
+  policy = jsonencode({
+    rules = [{
+        rulePriority = 1
+        description  = "Keep last 10 images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 10
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/infra/terraform/modules/ecr/outputs.tf
+++ b/infra/terraform/modules/ecr/outputs.tf
@@ -1,0 +1,3 @@
+output "repository_url" {
+  value = aws_ecr_repository.main.repository_url
+}

--- a/infra/terraform/modules/ecr/variables.tf
+++ b/infra/terraform/modules/ecr/variables.tf
@@ -1,0 +1,7 @@
+variable "project" {
+  type = string
+}
+
+variable "env" {
+  type = string
+}


### PR DESCRIPTION
## 📊 요약

- Docker 이미지 저장소로 사용할 ECR 리포지토리를 Terraform 모듈로 코드화했습니다.
- 이미지 취약점 스캔과 보관 정책을 포함해 운영 기반을 함께 구성했습니다.

## 🚨 Breaking Change?

- [ ] 있음
- [x] 없음

## 🧾 PR 타입

- [ ] ✨ 기능
- [ ] 🐛 버그
- [ ] ♻️ 리팩터
- [x] 🔧 기타(빌드·CI·문서)

## ✅ 체크리스트

- [x] CI 통과 (lint, type, test)
- [ ] 테스트 코드 추가·수정
- [ ] 문서/주석 업데이트
- [x] 개인정보 / 민감정보 제거

## 📚 상세

### 💬 추가 / 변경된 부분

**추가된 모듈:**
- `modules/ecr/` — ECR 리포지토리, push 시 이미지 스캔, lifecycle policy (최대 10개 유지)
- `environments/dev/main.tf` — ecr 모듈 호출 추가

### 📣 리뷰 노트

- `scan_on_push = true` — push마다 취약점 스캔 활성화
- lifecycle policy로 오래된 이미지 자동 삭제, 스토리지 비용 관리
- `terraform plan` 기준 신규 리소스: `aws_ecr_repository`, `aws_ecr_lifecycle_policy` (2 to add)

## 🔗 관련 이슈

Closes #10