### PR TITLE
[INFRA] Terraform S3 backend 및 DynamoDB remote state 설정

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -7,6 +7,14 @@ terraform {
       version = "~> 5.0"
     }
   }
+
+  backend "s3" {
+    bucket = "disasterkok-tfstate"
+    key    = "dev/terraform.tfstate"
+    region = "ap-northeast-2"
+    dynamodb_table = "disasterkok-tfstate-lock"
+    encrypt = true
+  }
 }
 
 provider "aws" {


### PR DESCRIPTION
## 📊 요약

- Terraform state를 S3에 저장하고 DynamoDB로 잠금을 관리하는 remote state를 구성했습니다.
- 로컬 state 파일의 민감 정보 노출 위험을 제거하고 협업 시 state 충돌을 방지합니다.

## 🚨 Breaking Change?

- [ ] 있음
- [x] 없음

## 🧾 PR 타입

- [ ] ✨ 기능
- [ ] 🐛 버그
- [ ] ♻️ 리팩터
- [x] 🔧 기타(빌드·CI·문서)

## ✅ 체크리스트

- [x] CI 통과 (lint, type, test)
- [ ] 테스트 코드 추가·수정
- [ ] 문서/주석 업데이트
- [x] 개인정보 / 민감정보 제거

## 📚 상세

### 💬 추가 / 변경된 부분

- `environments/dev/main.tf` — `backend "s3"` 블록 추가
- S3 버킷(`disasterkok-tfstate`), DynamoDB 테이블(`disasterkok-tfstate-lock`) 수동 생성 (chicken-and-egg 문제로 Terraform 외부에서 관리)

### 📣 리뷰 노트

- `encrypt = true` — S3 서버 사이드 암호화로 state 내 민감 정보 보호
- S3 버킷 버전 관리 활성화 — 잘못된 apply 후 이전 state로 롤백 가능
- DynamoDB `LockID` 파티션 키 — Terraform 요구사항, 동시 apply 시 잠금 보장
- `terraform init -migrate-state` 수행 결과: 로컬 state 없음, S3 backend 직접 연결 완료
- `terraform plan` 기준 Plan: 12 to add, 0 to change, 0 to destroy ✅

## 🔗 관련 이슈

Closes #11