### PR TITLE
[INFRA] EC2 user_data 스크립트로 k3s 설치 자동화

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -49,6 +49,7 @@ module "ec2" {
   security_group_id     = module.security_group.k3s_sg_id
   instance_profile_name = module.iam.instance_profile_name
   key_name              = var.key_name
+  k3s_version           = var.k3s_version
 }
 
 module "ecr" {

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -22,3 +22,8 @@ variable "key_name" {
   type        = string
   description = "EC2 Key Pair 이름"
 }
+
+variable "k3s_version" {
+  type    = string
+  default = "v1.32.3+k3s1"
+}

--- a/infra/terraform/modules/ec2/main.tf
+++ b/infra/terraform/modules/ec2/main.tf
@@ -14,16 +14,22 @@ data "aws_ami" "al2023" {
 }
 
 resource "aws_instance" "main" {
-  ami                    = data.aws_ami.al2023.id
-  instance_type          = var.instance_type
-  subnet_id              = var.subnet_id
+  ami                  = data.aws_ami.al2023.id
+  instance_type        = var.instance_type
+  subnet_id            = var.subnet_id
   vpc_security_group_ids = [var.security_group_id]
-  iam_instance_profile   = var.instance_profile_name
-  key_name               = var.key_name
+  iam_instance_profile = var.instance_profile_name
+  key_name             = var.key_name
 
   tags = {
     Name    = "${var.project}-${var.env}-node"
     Project = var.project
     Env     = var.env
   }
+
+  user_data = templatefile("${path.module}/user_data.sh", {
+    k3s_version = var.k3s_version
+  })
+
+user_data_replace_on_change = true
 }

--- a/infra/terraform/modules/ec2/user_data.sh
+++ b/infra/terraform/modules/ec2/user_data.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+LOG=/var/log/user_data.log
+exec > >(tee -a "$LOG") 2>&1
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] user_data 시작"
+
+# ── 시스템 업데이트 ────────────────────────────────────────────
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] 패키지 업데이트"
+dnf update -y
+
+# ── k3s 설치 ──────────────────────────────────────────────────
+K3S_VERSION="${k3s_version}"
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] k3s $K3S_VERSION 설치 시작"
+
+curl -sfL https://get.k3s.io | \
+INSTALL_K3S_VERSION="$K3S_VERSION" \
+INSTALL_K3S_EXEC="server --disable traefik" \
+sh -
+
+# ── k3s 서비스 활성화 확인 ────────────────────────────────────
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] k3s 서비스 상태 확인"
+systemctl enable k3s
+systemctl is-active k3s || { echo "[ERROR] k3s 서비스 시작 실패"; exit 1; }
+
+# ── kubeconfig 권한 설정 ──────────────────────────────────────
+chmod 644 /etc/rancher/k3s/k3s.yaml
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] user_data 완료"

--- a/infra/terraform/modules/ec2/variables.tf
+++ b/infra/terraform/modules/ec2/variables.tf
@@ -26,3 +26,8 @@ variable "instance_type" {
   type    = string
   default = "t3.small"
 }
+
+variable "k3s_version" {
+  type        = string
+  description = "설치할 k3s 버전 (예: v1.32.3+k3s1)"
+}


### PR DESCRIPTION
## 📊 요약

EC2 인스턴스 부팅 시 k3s를 자동으로 설치하는 `user_data.sh` 스크립트를 작성하고 Terraform EC2 모듈에 연결

기존에는 인스턴스 생성 후 SSH로 접속해 수동으로 k3s를 설치해야 했으나, 이번 변경으로 `terraform apply` 한 번으로 EC2 생성과 k3s 설치가 완전히 자동화됨

## 🚨 Breaking Change?

- [ ] 있음
- [x] 없음

## 🧾 PR 타입

- [ ] ✨ 기능
- [ ] 🐛 버그
- [ ] ♻️ 리팩터
- [x] 🔧 기타(빌드·CI·문서)

## ✅ 체크리스트

- [x] CI 통과 (lint, type, test)
- [ ] 테스트 코드 추가·수정
- [ ] 문서/주석 업데이트
- [x] 개인정보 / 민감정보 제거

## 📚 상세

### 💬 추가 / 변경된 부분

- `infra/terraform/modules/ec2/user_data.sh` 추가
  - k3s 버전 고정 설치 (`INSTALL_K3S_VERSION` 환경변수로 제어)
  - Traefik 비활성화 (`--disable traefik`) — 추후 Nginx Ingress 직접 구성 예정
  - 설치 로그 `/var/log/user_data.log`에 타임스탬프와 함께 기록
  - `set -euo pipefail`로 에러 발생 시 즉시 종료
- `modules/ec2/main.tf` — `templatefile()`로 user_data 연결, `user_data_replace_on_change = true` 설정
- `modules/ec2/variables.tf` — `k3s_version` 변수 추가
- `environments/dev/variables.tf` — `k3s_version` 변수 선언 및 기본값(`v1.32.3+k3s1`) 설정
- `environments/dev/main.tf` — EC2 모듈 호출에 `k3s_version` 전달

### 📣 리뷰 노트

- `terraform.tfvars`는 개인 IP 포함으로 gitignore 처리 — k3s 버전 기본값은 `variables.tf`에 명시
- `user_data_replace_on_change = true` 설정으로 스크립트 변경 시 EC2 재생성 보장
- `terraform validate` 및 `terraform plan` 확인 완료

## 🔗 관련 이슈
Closes #17 