### PR TITLE
[INFRA] EC2 프로비저닝 및 k3s 설치 확인

### DIFF
--- a/infra/terraform/environments/dev/outputs.tf
+++ b/infra/terraform/environments/dev/outputs.tf
@@ -1,0 +1,7 @@
+output "ec2_public_ip" {
+  value = module.ec2.public_ip
+}
+
+output "ec2_instance_id" {
+    value = module.ec2.instance_id
+}


### PR DESCRIPTION
## 📊 요약

dev 환경 EC2 outputs.tf 연결 누락 수정 및 terraform apply로 EC2 프로비저닝, k3s 설치 확인

## 🚨 Breaking Change?

- [ ] 있음
- [x] 없음

## 🧾 PR 타입

- [x] 🔧 기타(빌드·CI·문서)

## ✅ 체크리스트

- [x] CI 통과 (lint, type, test)
- [x] 문서/주석 업데이트
- [x] 개인정보 / 민감정보 제거

## 📚 상세

### 💬 추가 / 변경된 부분

- `environments/dev/outputs.tf`: EC2 public IP, instance ID output 연결 (`module.ec2.public_ip`)
- `terraform apply`로 EC2 프로비저닝 완료
- user_data 스크립트 실행 후 k3s 설치 확인
- `kubectl get nodes` Ready 상태 검증

### 📣 리뷰 노트

- 기존 `outputs.tf`에 플레이스홀더만 있고 실제 module output이 연결되지 않아 `ec2_public_ip`가 출력되지 않는 문제 수정
- k3s 설치 로그: `/var/log/user_data.log`
- 검증: `sudo kubectl get nodes` → STATUS Ready 확인

## 🔗 관련 이슈

Closes #19 