### PR TITLE
[INFRA] Django 및 Nginx Kubernetes 매니페스트 작성

### DIFF
--- a/infra/kubernetes/django/daphne-deploy.yaml
+++ b/infra/kubernetes/django/daphne-deploy.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: daphne
+  namespace: disasterkok
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: daphne
+  template:
+    metadata:
+      labels:
+        app: daphne
+    spec:
+      containers:
+        - name: daphne
+          image: 837497586799.dkr.ecr.ap-northeast-2.amazonaws.com/disasterkok-dev:latest
+          command: [ "daphne", "-b", "0.0.0.0", "-p", "8001", "config.asgi:application" ]
+          ports:
+            - containerPort: 8001
+          env:
+            - name: DJANGO_SETTINGS_MODULE
+              value: "config.settings.production"
+          envFrom:
+            - secretRef:
+                name: django-secret

--- a/infra/kubernetes/django/daphne-svc.yaml
+++ b/infra/kubernetes/django/daphne-svc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: daphne
+  namespace: disasterkok
+spec:
+  selector:
+    app: daphne
+  ports:
+    - port: 8001
+      targetPort: 8001
+  type: ClusterIP

--- a/infra/kubernetes/django/gunicorn-deploy.yaml
+++ b/infra/kubernetes/django/gunicorn-deploy.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gunicorn
+  namespace: disasterkok
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gunicorn
+  template:
+    metadata:
+      labels:
+        app: gunicorn
+    spec:
+      containers:
+        - name: gunicorn
+          image: 837497586799.dkr.ecr.ap-northeast-2.amazonaws.com/disasterkok-dev:latest
+          command: [ "gunicorn", "--bind", "0.0.0.0:8000", "--workers", "3", "config.wsgi:application" ]
+          ports:
+            - containerPort: 8000
+          env:
+            - name: DJANGO_SETTINGS_MODULE
+              value: "config.settings.production"
+          envFrom:
+            - secretRef:
+                name: django-secret
+          livenessProbe:
+            httpGet:
+              path: /health/
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health/
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 5

--- a/infra/kubernetes/django/gunicorn-svc.yaml
+++ b/infra/kubernetes/django/gunicorn-svc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: gunicorn
+    namespace: disasterkok
+spec:
+    selector:
+        app: gunicorn
+    ports:
+        - port: 8000
+          targetPort: 8000
+    type: ClusterIP

--- a/infra/kubernetes/namespace.yaml
+++ b/infra/kubernetes/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: disasterkok

--- a/infra/kubernetes/nginx/configmap.yaml
+++ b/infra/kubernetes/nginx/configmap.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: disasterkok
+data:
+  default.conf: |
+    upstream django_http {
+        server gunicorn:8000;
+    }
+
+    upstream django_ws {
+        server daphne:8001;
+    }
+
+    server {
+        listen 80;
+        server_name _;
+        client_max_body_size 20M;
+
+        location /ws/ {
+            proxy_pass http://django_ws;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_read_timeout 86400;
+            proxy_send_timeout 86400;
+        }
+
+        location /static/ {
+            alias /app/static/;
+            expires 30d;
+        }
+
+        location / {
+            proxy_pass http://django_http;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_connect_timeout 60s;
+            proxy_read_timeout 60s;
+        }
+    }

--- a/infra/kubernetes/nginx/deploy.yaml
+++ b/infra/kubernetes/nginx/deploy.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: disasterkok
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: nginx-config

--- a/infra/kubernetes/nginx/svc.yaml
+++ b/infra/kubernetes/nginx/svc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: disasterkok
+spec:
+  selector:
+    app: nginx
+  ports:
+    - port: 80
+      targetPort: 80
+      nodePort: 30080
+  type: NodePort


### PR DESCRIPTION
## 📊 요약

k3s 클러스터에 Django 앱을 배포하기 위한 Kubernetes 매니페스트를 작성

- Namespace, Django(gunicorn/daphne) Deployment/Service, Nginx ConfigMap/Deployment/Service 구성
- gunicorn/daphne는 독립 Deployment로 분리하여 개별 스케일링 가능한 구조 적용
- Nginx는 NodePort(30080)로 외부 노출, Django는 ClusterIP로 내부 통신만 허용

## 🚨 Breaking Change?

- [x] 없음

## 🧾 PR 타입

- [x] 🔧 기타(빌드·CI·문서)

## ✅ 체크리스트

- [x] CI 통과 (lint, type, test)
- [x] 개인정보 / 민감정보 제거

## 📚 상세

### 💬 추가 / 변경된 부분

```
infra/kubernetes/
├── namespace.yaml
├── django/
│   ├── gunicorn-deploy.yaml   # Deployment + livenessProbe/readinessProbe
│   ├── gunicorn-svc.yaml      # ClusterIP :8000
│   ├── daphne-deploy.yaml     # WebSocket 전용
│   └── daphne-svc.yaml        # ClusterIP :8001
└── nginx/
    ├── configmap.yaml         # nginx.conf (upstream gunicorn/daphne)
    ├── deploy.yaml            # ConfigMap volume mount
    └── svc.yaml               # NodePort :30080
```

### 📣 리뷰 노트

- `kubectl apply -f infra/kubernetes/ -R` 오류 없이 통과 확인
- nginx Pod Running 확인
- gunicorn/daphne는 `django-secret` Secret 미생성으로 `CreateContainerConfigError` 상태 — 다음 PR에서 Secret/ConfigMap 구성 예정

## 🔗 관련 이슈

Closes #21 