### PR TITLE
[INFRA] PostgreSQL/Redis Kubernetes 매니페스트 작성

### DIFF
--- a/infra/kubernetes/postgres/deploy.yaml
+++ b/infra/kubernetes/postgres/deploy.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: disasterkok
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: django-secret
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: django-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: django-secret
+                  key: POSTGRES_PASSWORD
+          volumeMounts:
+            - name: postgres-storage
+              mountPath: /var/lib/postgresql/data
+      volumes:
+      - name: postgres-storage
+        persistentVolumeClaim:
+          claimName: postgres-pvc
+

--- a/infra/kubernetes/postgres/pvc.yaml
+++ b/infra/kubernetes/postgres/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+  namespace: disasterkok
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/infra/kubernetes/postgres/svc.yaml
+++ b/infra/kubernetes/postgres/svc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: disasterkok
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/infra/kubernetes/redis/deploy.yaml
+++ b/infra/kubernetes/redis/deploy.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: disasterkok
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6379

--- a/infra/kubernetes/redis/svc.yaml
+++ b/infra/kubernetes/redis/svc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: disasterkok
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379


### PR DESCRIPTION
## 📊 요약

- PostgreSQL(postgres:15), Redis(redis:7-alpine) Kubernetes 매니페스트 작성
- PVC로 postgres 데이터 영속성 확보
- ClusterIP Service로 클러스터 내부 접근만 허용

## 🚨 Breaking Change?

- [x] 없음

## 🧾 PR 타입

- [x] 🔧 기타(빌드·CI·문서)

## ✅ 체크리스트

- [ ] CI 통과 (lint, type, test)
- [ ] 테스트 코드 추가·수정
- [ ] 문서/주석 업데이트
- [x] 개인정보 / 민감정보 제거

## 📚 상세

### 💬 추가 / 변경된 부분

**PostgreSQL**
- `pvc.yaml` — 1Gi ReadWriteOnce PVC, k3s local-path provisioner 활용
- `deploy.yaml` — postgres:15, django-secret에서 DB 자격증명 참조
- `svc.yaml` — ClusterIP, Service name `postgres` → Django `POSTGRES_HOST` 매칭

**Redis**
- `deploy.yaml` — redis:7-alpine, docker-compose 버전과 동일
- `svc.yaml` — ClusterIP, Service name `redis` → Django `REDIS_HOST` 매칭

### 📣 리뷰 노트

- postgres Deployment가 `django-secret`을 참조하므로 Secret 미생성 시 `CreateContainerConfigError` 발생 → Issue #24에서 해결 예정
- docker-compose.yml의 이미지 버전(postgres:15, redis:7-alpine)과 동일하게 맞춤

## 🔗 관련 이슈

Closes #23 