### PR TITLE
[INFRA] Django Secret 구성 및 CreateContainerConfigError 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.tfstate
 *.tfstate.backup
 *.tfvars
+infra/kubernetes/**/secret.yaml
 
 ### Django ###
 *.log

--- a/infra/kubernetes/django/secret.yaml.example
+++ b/infra/kubernetes/django/secret.yaml.example
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: django-secret
+  namespace: disasterkok
+type: Opaque
+stringData:
+  SECRET_KEY: "your-django-secret-key"
+  DEBUG: "False"
+  ALLOWED_HOSTS: "localhost,127.0.0.1"
+  POSTGRES_DB: "your-db-name"
+  POSTGRES_USER: "your-db-user"
+  POSTGRES_PASSWORD: "your-db-password"
+  POSTGRES_HOST: "postgres"
+  POSTGRES_PORT: "5432"
+  REDIS_HOST: "redis"
+  REDIS_PORT: "6379"


### PR DESCRIPTION
## 📊 요약

- `secret.yaml.example` 템플릿 추가로 Secret 구성 방법 문서화
- `.gitignore`에 `infra/kubernetes/**/secret.yaml` 패턴 추가로 실제 Secret 파일 커밋 차단

## 🚨 Breaking Change?

- [x] 없음

## 🧾 PR 타입

- [x] 🔧 기타(빌드·CI·문서)

## ✅ 체크리스트

- [ ] CI 통과 (lint, type, test)
- [ ] 테스트 코드 추가·수정
- [ ] 문서/주석 업데이트
- [x] 개인정보 / 민감정보 제거

## 📚 상세

### 💬 추가 / 변경된 부분

- `infra/kubernetes/django/secret.yaml.example` — Django 앱이 필요로 하는 모든 환경 변수 키 포함 (SECRET_KEY, DB, Redis 등)
- `.gitignore` — `infra/kubernetes/**/secret.yaml` 패턴으로 하위 모든 Secret 파일 차단

### 📣 리뷰 노트

실제 클러스터 적용 시 아래 절차를 따름
1. `secret.yaml.example`을 복사해 `secret.yaml` 생성
2. 실제 값으로 채운 뒤 `kubectl apply -f infra/kubernetes/django/secret.yaml`
3. gunicorn/daphne Pod `CreateContainerConfigError` → `Running` 전환 확인

## 🔗 관련 이슈

`Closes #24`