### PR TITLE
[INFRA] ECR force_delete 옵션 추가

### DIFF
--- a/infra/terraform/modules/ecr/main.tf
+++ b/infra/terraform/modules/ecr/main.tf
@@ -1,5 +1,6 @@
 resource "aws_ecr_repository" "main" {
   name                 = "${var.project}-${var.env}"
+  force_delete         = true
   image_tag_mutability = "MUTABLE"
 
   image_scanning_configuration {


### PR DESCRIPTION
## 📊 요약

- ECR 레포지토리에 `force_delete = true` 추가
- 이미지가 남아있어도 `terraform destroy` 한 번에 완료

## 🚨 Breaking Change?

- [x] 없음

## 🧾 PR 타입

- [x] 🔧 기타(빌드·CI·문서)

## ✅ 체크리스트

- [ ] CI 통과 (lint, type, test)
- [ ] 테스트 코드 추가·수정
- [ ] 문서/주석 업데이트
- [x] 개인정보 / 민감정보 제거

## 📚 상세

### 💬 추가 / 변경된 부분

`infra/terraform/modules/ecr/main.tf`에 `force_delete = true` 추가

### 📣 리뷰 노트

terraform destroy 시 ECR 이미지를 수동으로 삭제하지 않아도 되도록 수정. 운영 환경에서는 실수로 삭제되는 것을 막기 위해 false로 설정하는 것이 바람직하나, dev 환경에서는 편의상 true로 설정.

## 🔗 관련 이슈

Closes #27 