### PR TITLE
[INFRA] k3s 배포 후 smoke test 자동화 스크립트 추가

### DIFF
--- a/infra/smoke-test.sh
+++ b/infra/smoke-test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+NAMESPACE="disasterkok"
+EC2_IP=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+PORT=30080
+
+echo "=== Pod 상태 확인 ==="
+kubectl get pods -n $NAMESPACE
+
+echo ""
+echo "=== Running 아닌 Pod 체크 ==="
+NOT_RUNNING=$(kubectl get pods -n $NAMESPACE --no-headers | grep -v "Running" | wc -l)
+if [ "$NOT_RUNNING" -gt 0 ]; then
+  echo "FAIL: Running 아닌 Pod 있음"
+  exit 1
+fi
+echo "PASS: 전체 Pod Running"
+
+echo ""
+echo "=== HTTP 200 체크 ==="
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://$EC2_IP:$PORT/)
+if [ "$STATUS" != "200" ]; then
+  echo "FAIL: HTTP $STATUS"
+  exit 1
+fi
+echo "PASS: HTTP $STATUS — http://$EC2_IP:$PORT/"
+
+echo ""
+echo "=== smoke test 완료 ==="


### PR DESCRIPTION
## 📊 요약

k3s 클러스터 재배포 후 전체 서비스 정상 동작을 검증하는 smoke test 스크립트를 추가한다

## 🚨 Breaking Change?

- [x] 없음

## 🧾 PR 타입

- [x] 🔧 기타(빌드·CI·문서)

## ✅ 체크리스트

- [x] 개인정보 / 민감정보 제거

## 📚 상세

### 💬 추가 / 변경된 부분

- `infra/smoke-test.sh` 추가
  - EC2 메타데이터에서 퍼블릭 IP 자동 조회
  - `kubectl get pods`로 전체 Pod Running 여부 확인
  - `curl` HTTP 200 응답 확인
  - 실패 시 non-zero exit code 반환 (CI 연동 가능)

### 📣 리뷰 노트

- EC2 안에서 실행하는 스크립트
- `terraform apply` 후 수동 검증 → CI/CD 완성 후 자동 실행으로 전환 예정
- 검증 결과: `http://3.36.118.73:30080/` HTTP 200, 전체 5개 Pod Running 확인

## 🔗 관련 이슈

Closes #29 