### PR TITLE
[INFRA] EC2 stop/start 운영 스크립트 작성

### DIFF
--- a/infra/ec2-start.sh
+++ b/infra/ec2-start.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+INSTANCE_ID=$(aws ec2 describe-instances \
+  --filters "Name=tag:Name,Values=disasterkok-dev-node" "Name=instance-state-name,Values=stopped" \
+  --query "Reservations[0].Instances[0].InstanceId" \
+  --output text \
+  --region ap-northeast-2)
+
+if [ "$INSTANCE_ID" = "None" ] || [ -z "$INSTANCE_ID" ]; then
+  echo "중지된 인스턴스를 찾을 수 없습니다"
+  exit 1
+fi
+
+echo "인스턴스 시작 중: $INSTANCE_ID"
+aws ec2 start-instances --instance-ids "$INSTANCE_ID" --region ap-northeast-2
+
+aws ec2 wait instance-running --instance-ids "$INSTANCE_ID" --region ap-northeast-2
+
+PUBLIC_IP=$(aws ec2 describe-instances \
+  --instance-ids "$INSTANCE_ID" \
+  --query "Reservations[0].Instances[0].PublicIpAddress" \
+  --output text \
+  --region ap-northeast-2)
+
+echo "시작 완료"
+echo "새 퍼블릭 IP: $PUBLIC_IP"
+echo ""
+echo "접속 명령:"
+echo "  ssh -i <키파일>.pem ec2-user@$PUBLIC_IP"

--- a/infra/ec2-stop.sh
+++ b/infra/ec2-stop.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+INSTANCE_ID=$(aws ec2 describe-instances \
+  --filters "Name=tag:Name,Values=disasterkok-dev-node" "Name=instance-state-name,Values=running" \
+  --query "Reservations[0].Instances[0].InstanceId" \
+  --output text \
+  --region ap-northeast-2)
+
+if [ "$INSTANCE_ID" = "None" ] || [ -z "$INSTANCE_ID" ]; then
+  echo "실행 중인 인스턴스를 찾을 수 없습니다"
+  exit 1
+fi
+
+echo "인스턴스 중지 중: $INSTANCE_ID"
+aws ec2 stop-instances --instance-ids "$INSTANCE_ID" --region ap-northeast-2
+
+aws ec2 wait instance-stopped --instance-ids "$INSTANCE_ID" --region ap-northeast-2
+echo "중지 완료: $INSTANCE_ID"


### PR DESCRIPTION
## 📊 요약

매일 `terraform destroy/apply` 대신 EC2 stop/start 패턴으로 전환하기 위한 운영 스크립트 추가

- `infra/ec2-stop.sh` — 인스턴스 중지 + stopped 상태 대기
- `infra/ec2-start.sh` — 인스턴스 시작 + running 상태 대기 + 새 퍼블릭 IP 출력

## 🚨 Breaking Change?

- [x] 없음

## 🧾 PR 타입

- [x] 🔧 기타(빌드·CI·문서)

## ✅ 체크리스트

- [x] 개인정보 / 민감정보 제거

## 📚 상세

### 💬 추가 / 변경된 부분

**배경**
- `terraform destroy/apply` 사이클은 EC2를 매번 새로 생성해 k3s, Secret, ECR 이미지를 수동 재설정해야 했음
- EC2 stop/start는 인스턴스 내부 상태(k3s, Pod, Secret)를 유지하며 비용만 절감

**동작 방식**
- `Name` 태그(`disasterkok-dev-node`)로 인스턴스를 동적 조회 — 인스턴스 ID 하드코딩 없음
- `aws ec2 wait`로 상태 전환 완료 후 다음 단계 진행
- `ec2-start.sh`는 시작 후 새 퍼블릭 IP와 SSH 접속 명령 출력

### 📣 리뷰 노트

실행 전 `aws configure` 또는 환경변수로 자격증명 설정 필요

```bash
# 중지
./infra/ec2-stop.sh

# 시작
./infra/ec2-start.sh
```

## 🔗 관련 이슈

Closes #31 