### PR TITLE
[INFRA] GitHub Actions build-and-push 워크플로우를 추가

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,43 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+env:
+  AWS_REGION: ap-northeast-2
+  ECR_REPOSITORY: disasterkok-dev
+jobs:
+  build-and-push:
+    name: Build and Push to ECR
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and Push Image
+        env:
+            ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+            IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build \
+          -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+          -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
+          -f Disasterkok_backend/Dockerfile \
+          Disasterkok_backend/
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest


### PR DESCRIPTION
## 📊 요약

push 이벤트 발생 시 Docker 이미지를 자동으로 빌드하고 ECR에 푸시하는 GitHub Actions 워크플로우 추가

- 트리거: `main` 브랜치 push
- AWS 자격증명: OIDC 방식 (IAM Role assume, Access Key 미사용)
- 이미지 태그: `latest` + 커밋 SHA (롤백을 위한 버전 추적)

## 🚨 Breaking Change?

- [x] 없음

## 🧾 PR 타입

- [x] 🔧 기타(빌드·CI·문서)

## ✅ 체크리스트

- [x] 개인정보 / 민감정보 제거

## 📚 상세

### 💬 추가 / 변경된 부분

`.github/workflows/deploy.yml` 신규 작성

**워크플로우 구성**
1. Checkout
2. AWS credentials 설정 (OIDC — `AWS_ROLE_ARN` 시크릿)
3. ECR 로그인
4. Docker 이미지 빌드 + ECR 푸시

**OIDC 선택 이유**
- 장기 Access Key를 저장하지 않아 키 탈취 위험 없음
- IAM Role Trust Policy에서 리포지토리/브랜치 단위 접근 제한 가능
- 임시 토큰은 1시간 이내 만료

### 📣 리뷰 노트

실제 실행을 위해 사전 설정 필요:
- AWS IAM: GitHub OIDC Identity Provider 등록
- AWS IAM: ECR 푸시 권한을 가진 Role 생성
- GitHub Secrets: `AWS_ROLE_ARN` 등록

## 🔗 관련 이슈

Closes #32 