### PR TITLE
[INFRA]GitHub Actions OIDC IAM Role을 Terraform으로 코드화

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -9,11 +9,11 @@ terraform {
   }
 
   backend "s3" {
-    bucket = "disasterkok-tfstate"
-    key    = "dev/terraform.tfstate"
-    region = "ap-northeast-2"
+    bucket         = "disasterkok-tfstate"
+    key            = "dev/terraform.tfstate"
+    region         = "ap-northeast-2"
     dynamodb_table = "disasterkok-tfstate-lock"
-    encrypt = true
+    encrypt        = true
   }
 }
 
@@ -36,9 +36,10 @@ module "security_group" {
 }
 
 module "iam" {
-  source  = "../../modules/iam"
-  project = var.project
-  env     = var.env
+  source      = "../../modules/iam"
+  project     = var.project
+  env         = var.env
+  github_repo = var.github_repo
 }
 
 module "ec2" {
@@ -53,7 +54,7 @@ module "ec2" {
 }
 
 module "ecr" {
-  source = "../../modules/ecr"
+  source  = "../../modules/ecr"
   project = var.project
-  env = var.env
+  env     = var.env
 }

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -27,3 +27,8 @@ variable "k3s_version" {
   type    = string
   default = "v1.32.3+k3s1"
 }
+
+variable "github_repo" {
+  type        = string
+  description = "GitHub 레포지토리 (owner/repo 형식)"
+}

--- a/infra/terraform/modules/iam/main.tf
+++ b/infra/terraform/modules/iam/main.tf
@@ -23,3 +23,40 @@ resource "aws_iam_instance_profile" "ec2" {
   name = "${var.project}-${var.env}-ec2-profile"
   role = aws_iam_role.ec2.name
 }
+
+# GitHub Actions OIDC Identity Provider
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+# GitHub Actions ECR 푸시용 IAM Role
+resource "aws_iam_role" "github_actions" {
+  name = "${var.project}-${var.env}-github-actions-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect = "Allow",
+      Principal = {
+        Federated = aws_iam_openid_connect_provider.github.arn
+      },
+      Action = "sts:AssumeRoleWithWebIdentity",
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+        },
+        StringLike = {
+          "token.actions.githubusercontent.com:sub" = "repo:${var.github_repo}:ref:refs/heads/main"
+        }
+      }
+    }]
+  })
+}
+
+# ECR 이미지 푸시 권한
+resource "aws_iam_role_policy_attachment" "github_actions_ecr" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
+}

--- a/infra/terraform/modules/iam/outputs.tf
+++ b/infra/terraform/modules/iam/outputs.tf
@@ -1,3 +1,7 @@
 output "instance_profile_name" {
   value       = aws_iam_instance_profile.ec2.name
 }
+
+output "github_actions_role_arn" {
+  value = aws_iam_role.github_actions.arn
+}

--- a/infra/terraform/modules/iam/variables.tf
+++ b/infra/terraform/modules/iam/variables.tf
@@ -5,3 +5,8 @@ variable "project" {
 variable "env" {
   type        = string
 }
+
+variable "github_repo" {
+  type        = string
+  description = "GitHub 레포지토리 (owner/repo 형식)"
+}


### PR DESCRIPTION
## 📊 요약

GitHub Actions CI/CD 파이프라인이 Access Key 없이 ECR에 이미지를 푸시할 수 있도록 OIDC 기반 IAM Role을 Terraform으로 코드화

- AWS IAM OIDC Identity Provider 추가 (token.actions.githubusercontent.com)
- ECR 푸시 권한 IAM Role 생성 (Trust Policy: gpffh20/Disasterkok main 브랜치 한정)
- AmazonEC2ContainerRegistryPowerUser 정책 연결
- `github_repo` 변수 추가, `github_actions_role_arn` output 추가

## 🚨 Breaking Change?

- [x] 없음

## 🧾 PR 타입

- [x] 🔧 기타(빌드·CI·문서)

## ✅ 체크리스트

- [x] CI 통과 (lint, type, test)
- [ ] 테스트 코드 추가·수정
- [x] 문서/주석 업데이트
- [x] 개인정보 / 민감정보 제거

## 📚 상세

### 💬 추가 / 변경된 부분

**`infra/terraform/modules/iam/main.tf`**
- `aws_iam_openid_connect_provider.github` 추가
- `aws_iam_role.github_actions` 추가 (Trust Policy: sub 조건으로 main 브랜치 한정)
- `aws_iam_role_policy_attachment.github_actions_ecr` 추가

**`infra/terraform/modules/iam/variables.tf`**
- `github_repo` 변수 추가

**`infra/terraform/modules/iam/outputs.tf`**
- `github_actions_role_arn` output 추가

**`infra/terraform/environments/dev/`**
- `main.tf`: iam 모듈에 `github_repo` 연결
- `variables.tf`: `github_repo` 변수 추가

### 📣 리뷰 노트

- OIDC 방식으로 장기 Access Key를 발급하지 않음
- Trust Policy의 `StringLike` 조건으로 main 브랜치 push에서만 Role assume 가능
- `terraform apply -target` 으로 IAM 리소스만 선택 적용 (기존 EC2 영향 없음)
- AWS 콘솔에서 OIDC Provider, IAM Role, 정책 연결 모두 확인 완료
- GitHub Secrets에 `AWS_ROLE_ARN` 등록 완료

## 🔗 관련 이슈

Closes #35 