### PR TITLE
[INFRA] CI/CD 워크플로우에 k3s rolling deploy 단계 추가

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,6 +14,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    outputs:
+        image: ${{ steps.build.outputs.image }}
 
     steps:
       - name: Checkout
@@ -30,6 +32,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Build and Push Image
+        id: build
         env:
             ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
             IMAGE_TAG: ${{ github.sha }}
@@ -41,3 +44,40 @@ jobs:
           Disasterkok_backend/
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+  deploy:
+    name: Deploy to k3s
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Rolling deploy via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ec2-user
+          key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
+          script: |
+            IMAGE=${{ needs.build-and-push.outputs.image }}
+            kubectl set image deployment/gunicorn gunicorn=$IMAGE -n disasterkok
+            kubectl set image deployment/daphne daphne=$IMAGE -n disasterkok
+            kubectl rollout status deployment/gunicorn -n disasterkok
+            kubectl rollout status deployment/daphne -n disasterkok
+
+      - name: Smoke Test
+        uses: appleboy/ssh-action@v1
+        with:
+            host: ${{ secrets.EC2_HOST }}
+            username: ec2-user
+            key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
+            script: /home/ec2-user/Disasterkok/smoke-test.sh


### PR DESCRIPTION
## 📊 요약

deploy.yaml의 build-and-push 이후 deploy job을 추가해 ECR 이미지 푸시부터 k3s rolling deploy, smoke test까지 엔드-투-엔드 파이프라인을 완성한다

## 🚨 Breaking Change?

- [ ] 있음
- [x] 없음

## 🧾 PR 타입

- [x] 🔧 기타(빌드·CI·문서)

## ✅ 체크리스트

- [ ] CI 통과 (lint, type, test)
- [ ] 테스트 코드 추가·수정
- [ ] 문서/주석 업데이트
- [ ] 개인정보 / 민감정보 제거

## 📚 상세

### 💬 추가 / 변경된 부분

- `build-and-push` job에 `outputs` 블록 추가 — ECR 이미지 URI를 deploy job으로 전달
- `Build and Push Image` step에 `id: build` 추가 — outputs 참조를 위한 step ID 지정
- `deploy` job 추가 (needs: build-and-push)
  - EC2 SSH 접속 → `kubectl set image` (gunicorn, daphne)
  - `kubectl rollout status`로 rolling update 완료 대기
  - smoke-test.sh 실행 (Pod Running 확인 + HTTP 200 확인)

### 📣 리뷰 노트

- GitHub Secrets 필요: `EC2_HOST`, `EC2_SSH_PRIVATE_KEY`
- EC2 인스턴스가 실행 중이어야 deploy job 정상 동작
- deploy job은 appleboy/ssh-action@v1 사용

## 🔗 관련 이슈

Closes #39 