### PR TITLE
develop → main: SSM 배포 파이프라인 엔드-투-엔드 검증

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
 
 env:
   AWS_REGION: ap-northeast-2
@@ -15,7 +15,7 @@ jobs:
       id-token: write
       contents: read
     outputs:
-        image: ${{ steps.build.outputs.image }}
+      image: ${{ steps.build.outputs.image }}
 
     steps:
       - name: Checkout
@@ -34,8 +34,8 @@ jobs:
       - name: Build and Push Image
         id: build
         env:
-            ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-            IMAGE_TAG: ${{ github.sha }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
         run: |
           docker build \
           -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
@@ -61,23 +61,63 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Rolling deploy via SSH
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ec2-user
-          key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
-          script: |
-            IMAGE=${{ needs.build-and-push.outputs.image }}
-            kubectl set image deployment/gunicorn gunicorn=$IMAGE -n disasterkok
-            kubectl set image deployment/daphne daphne=$IMAGE -n disasterkok
-            kubectl rollout status deployment/gunicorn -n disasterkok
-            kubectl rollout status deployment/daphne -n disasterkok
+      - name: Rolling deploy via SSM
+        env:
+          IMAGE: ${{ needs.build-and-push.outputs.image }}
+        run: |
+          INSTANCE_ID=$(aws ec2 describe-instances \
+            --filters "Name=tag:Name,Values=disasterkok-dev-node" \
+            --query "Reservations[0].Instances[0].InstanceId" \
+            --output text)
+            
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids $INSTANCE_ID \
+            --document-name "AWS-RunShellScript" \
+            --parameters commands="[
+              'kubectl set image deployment/gunicorn gunicorn=$IMAGE -n disasterkok',
+              'kubectl set image deployment/daphne daphne=$IMAGE -n disasterkok',
+              'kubectl rollout status deployment/gunicorn -n disasterkok --timeout=120s',
+              'kubectl rollout status deployment/daphne -n disasterkok --timeout=120s'
+            ]" \
+            --query "Command.CommandId" \
+            --output text)
+          
+          aws ssm wait command-executed \
+            --command-id $COMMAND_ID \
+            --instance-id $INSTANCE_ID
+          
+          STATUS=$(aws ssm get-command-invocation \
+            --command-id $COMMAND_ID \
+            --instance-id $INSTANCE_ID \
+            --query "StatusDetails" \
+            --output text)
+          
+          echo "Deploy status: $STATUS"
+          [ "$STATUS" = "Success" ] || exit 1
 
-      - name: Smoke Test
-        uses: appleboy/ssh-action@v1
-        with:
-            host: ${{ secrets.EC2_HOST }}
-            username: ec2-user
-            key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
-            script: /home/ec2-user/Disasterkok/smoke-test.sh
+      - name: Smoke Test via SSM
+        run: |
+            INSTANCE_ID=$(aws ec2 describe-instances \
+              --filters "Name=tag:Name,Values=disasterkok-dev-node" \
+              --query "Reservations[0].Instances[0].InstanceId" \
+              --output text)
+                
+            COMMAND_ID=$(aws ssm send-command \
+              --instance-ids $INSTANCE_ID \
+              --document-name "AWS-RunShellScript" \
+              --parameters commands="['/home/ec2-user/Disasterkok/smoke-test.sh']" \
+              --query "Command.CommandId" \
+              --output text)
+            
+            aws ssm wait command-executed \
+              --command-id $COMMAND_ID \
+              --instance-id $INSTANCE_ID
+            
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id $COMMAND_ID \
+              --instance-id $INSTANCE_ID \
+              --query "StatusDetails" \
+              --output text)
+            
+            echo "Smoke test status: $STATUS"
+            [ "$STATUS" = "Success" ] || exit 1

--- a/infra/terraform/modules/iam/main.tf
+++ b/infra/terraform/modules/iam/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.17.0"
+    }
+  }
+}
 # EC2가 AWS 서비스를 assume 할 수 있도록 허용하는 Trust Policy
 resource "aws_iam_role" "ec2" {
   name = "${var.project}-${var.env}-ec2-role"
@@ -59,4 +67,32 @@ resource "aws_iam_role" "github_actions" {
 resource "aws_iam_role_policy_attachment" "github_actions_ecr" {
   role       = aws_iam_role.github_actions.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
+}
+
+# EC2가 SSM Agent로 SSM 연결 권한
+resource "aws_iam_role_policy_attachment" "ec2_ssm" {
+  role        = aws_iam_role.ec2.name
+  policy_arn  = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+# Github Actions가 SSM을 통해 EC2에 명령 전송 권한
+resource "aws_iam_role_policy" "github_actions_ssm" {
+  name  = "${var.project}-${var.env}-github-actions-ssm"
+  role  = aws_iam_role.github_actions.name
+
+policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = ["ssm:SendCommand", "ssm:GetCommandInvocation"],
+      Resource = "*"
+    },
+      {
+        Effect = "Allow",
+        Action = ["ec2:DescribeInstances"],
+        Resource = "*"
+       }
+      ]
+  })
 }

--- a/infra/terraform/modules/security-group/main.tf
+++ b/infra/terraform/modules/security-group/main.tf
@@ -4,14 +4,6 @@ resource "aws_security_group" "k3s" {
   vpc_id      = var.vpc_id
 
   ingress {
-    description = "SSH"
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = [var.my_ip]
-  }
-
-  ingress {
     description = "HTTP"
     from_port   = 80
     to_port     = 80


### PR DESCRIPTION
## 📊 요약

SSH 대신 SSM send-command 기반 배포 파이프라인을 main에 반영해 커밋 push → ECR push → k3s rolling deploy → smoke test 엔드-투-엔드 검증을 수행한다

## 🚨 Breaking Change?

- [ ] 있음
- [x] 없음

## 🧾 PR 타입

- [x] 🔧 기타(빌드·CI·문서)

## ✅ 체크리스트

- [ ] CI 통과 (lint, type, test)
- [ ] 테스트 코드 추가·수정
- [ ] 문서/주석 업데이트
- [ ] 개인정보 / 민감정보 제거

## 📚 상세

### 💬 추가 / 변경된 부분

- SSH → SSM send-command 전환, port 22 제거
- EC2/GitHub Actions IAM Role SSM 권한 추가
- POSTGRES_HOST 기본값 수정 (db → postgres)
- IAM 모듈 provider 버전 중복 선언 제거

## 🔗 관련 이슈

Closes #42 