### PR TITLE
develop → main: smoke-test 경로 수정

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -105,7 +105,7 @@ jobs:
             COMMAND_ID=$(aws ssm send-command \
               --instance-ids $INSTANCE_ID \
               --document-name "AWS-RunShellScript" \
-              --parameters commands="['/home/ec2-user/Disasterkok/smoke-test.sh']" \
+              --parameters commands="['/home/ssm-user/Disasterkok/infra/smoke-test.sh']" \
               --query "Command.CommandId" \
               --output text)
             

--- a/Disasterkok_backend/webapp/config/settings/production.py
+++ b/Disasterkok_backend/webapp/config/settings/production.py
@@ -9,7 +9,7 @@ DATABASES = {
         'NAME': os.environ.get("POSTGRES_DB"),
         'USER': os.environ.get("POSTGRES_USER"),
         'PASSWORD': os.environ.get("POSTGRES_PASSWORD"),
-        'HOST': os.environ.get("POSTGRES_HOST", "db"),
+        'HOST': os.environ.get("POSTGRES_HOST", "postgres"),
         'PORT': os.environ.get("POSTGRES_PORT", "5432"),
     }
 }

--- a/infra/terraform/modules/iam/main.tf
+++ b/infra/terraform/modules/iam/main.tf
@@ -1,11 +1,3 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "6.17.0"
-    }
-  }
-}
 # EC2가 AWS 서비스를 assume 할 수 있도록 허용하는 Trust Policy
 resource "aws_iam_role" "ec2" {
   name = "${var.project}-${var.env}-ec2-role"


### PR DESCRIPTION
## 📊 요약

SSM send-command는 ssm-user로 실행되어 ec2-user 기준 경로를 인식하지 못하는 문제를 수정한다

## 🚨 Breaking Change?

- [ ] 있음
- [x] 없음

## 🧾 PR 타입

- [x] 🐛 버그

## 📚 상세

### 💬 추가 / 변경된 부분

- smoke-test 경로: `/home/ec2-user/Disasterkok/smoke-test.sh` → `/home/ssm-user/Disasterkok/infra/smoke-test.sh`

## 🔗 관련 이슈

Refs #42 