### PR TITLE
develop → main: smoke-test localhost 수정

### DIFF
--- a/infra/smoke-test.sh
+++ b/infra/smoke-test.sh
@@ -2,7 +2,6 @@
 set -e
 
 NAMESPACE="disasterkok"
-EC2_IP=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
 PORT=30080
 
 echo "=== Pod 상태 확인 ==="
@@ -19,12 +18,12 @@ echo "PASS: 전체 Pod Running"
 
 echo ""
 echo "=== HTTP 200 체크 ==="
-STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://$EC2_IP:$PORT/)
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$PORT/)
 if [ "$STATUS" != "200" ]; then
   echo "FAIL: HTTP $STATUS"
   exit 1
 fi
-echo "PASS: HTTP $STATUS — http://$EC2_IP:$PORT/"
+echo "PASS: HTTP $STATUS — http://localhost:$PORT/"
 
 echo ""
 echo "=== smoke test 완료 ==="


### PR DESCRIPTION
## 📊 요약

smoke-test.sh에서 IMDSv2 환경에서 빈 값이 되는 EC2_IP 제거, localhost로 HTTP 체크 변경

## 🚨 Breaking Change?

- [ ] 있음
- [x] 없음

## 🧾 PR 타입

- [x] 🐛 버그

## 📚 상세

### 💬 추가 / 변경된 부분

- IMDSv1 퍼블릭 IP 조회 제거 (IMDSv2 적용 환경에서 빈 값 반환)
- HTTP 체크 대상: `http://$EC2_IP:30080/` → `http://localhost:30080/`

## 🔗 관련 이슈

Refs #42 