### PR TITLE
develop → main: smoke-test KUBECONFIG 명시적 설정

### DIFF
--- a/infra/smoke-test.sh
+++ b/infra/smoke-test.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+
 NAMESPACE="disasterkok"
 PORT=30080
 


### PR DESCRIPTION
## 📊 요약

SSM send-command는 root로 실행되어 KUBECONFIG 환경변수가 없어 kubectl 실패하는 문제를 수정한다

## 🚨 Breaking Change?

- [ ] 있음
- [x] 없음

## 🧾 PR 타입

- [x] 🐛 버그

## 📚 상세

### 💬 추가 / 변경된 부분

- smoke-test.sh 상단에 `export KUBECONFIG=/etc/rancher/k3s/k3s.yaml` 추가
- SSM send-command(root 실행)와 직접 실행 환경 모두에서 동작

## 🔗 관련 이슈

`Refs #42`