### PR TITLE
develop → main: smoke test SSM 출력 로깅 추가

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -118,6 +118,18 @@ jobs:
               --instance-id $INSTANCE_ID \
               --query "StatusDetails" \
               --output text)
+          
+            aws ssm get-command-invocation \
+              --command-id $COMMAND_ID \
+              --instance-id $INSTANCE_ID \
+              --query "StandardOutputContent" \
+              --output text
+
+            aws ssm get-command-invocation \
+              --command-id $COMMAND_ID \
+              --instance-id $INSTANCE_ID \
+              --query "StandardErrorContent" \
+              --output text
             
             echo "Smoke test status: $STATUS"
             [ "$STATUS" = "Success" ] || exit 1


### PR DESCRIPTION
## 📊 요약

SSM send-command 실패 시 StandardOutputContent, StandardErrorContent를 GHA 로그에 출력해 디버깅 가능하게 한다

## 🚨 Breaking Change?

- [ ] 있음
- [x] 없음

## 🧾 PR 타입

- [x] 🐛 버그

## 🔗 관련 이슈

`Refs #42`