### PR TITLE
develop → main: smoke-test 안정성 개선

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -77,7 +77,8 @@ jobs:
               'kubectl set image deployment/gunicorn gunicorn=$IMAGE -n disasterkok',
               'kubectl set image deployment/daphne daphne=$IMAGE -n disasterkok',
               'kubectl rollout status deployment/gunicorn -n disasterkok --timeout=120s',
-              'kubectl rollout status deployment/daphne -n disasterkok --timeout=120s'
+              'kubectl rollout status deployment/daphne -n disasterkok --timeout=120s',
+              'sleep 10'
             ]" \
             --query "Command.CommandId" \
             --output text)
@@ -111,7 +112,7 @@ jobs:
             
             aws ssm wait command-executed \
               --command-id $COMMAND_ID \
-              --instance-id $INSTANCE_ID
+              --instance-id $INSTANCE_ID || true
             
             STATUS=$(aws ssm get-command-invocation \
               --command-id $COMMAND_ID \

--- a/infra/smoke-test.sh
+++ b/infra/smoke-test.sh
@@ -11,7 +11,7 @@ kubectl get pods -n $NAMESPACE
 
 echo ""
 echo "=== Running 아닌 Pod 체크 ==="
-NOT_RUNNING=$(kubectl get pods -n $NAMESPACE --no-headers | grep -v "Running" | wc -l)
+NOT_RUNNING=$(kubectl get pods -n $NAMESPACE --no-headers | grep -v -E "Running|Terminating" | wc -l)
 if [ "$NOT_RUNNING" -gt 0 ]; then
   echo "FAIL: Running 아닌 Pod 있음"
   exit 1


### PR DESCRIPTION
## 📊 요약

smoke-test 실패 원인 수정 및 SSM 출력 로깅 추가

## 🚨 Breaking Change?

- [ ] 있음
- [x] 없음

## 🧾 PR 타입

- [x] 🐛 버그

## 📚 상세

### 💬 추가 / 변경된 부분

- grep -E 플래그 누락 수정 (Terminating Pod OR 조건 미작동 버그)
- Rolling deploy 후 sleep 10 추가 (Terminating Pod 정리 대기)
- SSM wait에 || true 추가 (실패 시에도 출력 로그 확인 가능)

## 🔗 관련 이슈

`Refs #42`