### PR TITLE
develop → main: smoke-test bash 명시적 실행

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -106,7 +106,7 @@ jobs:
             COMMAND_ID=$(aws ssm send-command \
               --instance-ids $INSTANCE_ID \
               --document-name "AWS-RunShellScript" \
-              --parameters commands="['/home/ssm-user/Disasterkok/infra/smoke-test.sh']" \
+              --parameters commands="['bash /home/ssm-user/Disasterkok/infra/smoke-test.sh']" \
               --query "Command.CommandId" \
               --output text)
             


### PR DESCRIPTION
## 📊 요약

SSM send-command에서 스크립트 직접 실행 시 Permission denied 문제를 bash로 명시적 실행하여 해결

## 🚨 Breaking Change?

- [ ] 있음
- [x] 없음

## 🧾 PR 타입

- [x] 🐛 버그

## 📚 상세

### 💬 추가 / 변경된 부분

- `/home/ssm-user/Disasterkok/infra/smoke-test.sh` → `bash /home/ssm-user/Disasterkok/infra/smoke-test.sh`

## 🔗 관련 이슈

`Refs #42`