### PR TITLE
[INFRA] workflow_dispatch 트리거 추가 및 Node.js 24 대응

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,6 +3,7 @@ name: Deploy
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 env:
   AWS_REGION: ap-northeast-2


### PR DESCRIPTION
## 문제

현재 deploy.yaml은 main 브랜치 push 시에만 트리거된다. 수동 실행 방법이 없어 디버깅 및 긴급 재배포 시 불편하다.

## 변경 내용

- `workflow_dispatch` 트리거 추가 → GitHub Actions UI에서 수동 실행 가능
- 기존 push 트리거 유지

## 검증 방법

- GitHub Actions → Deploy → Run workflow 버튼 노출 확인
- 수동 실행 후 build-and-push, deploy job 정상 통과 확인

Closes #43 