### PR TITLE
[INFRA] EC2 AMI 고정 및 초기 세팅 자동화

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -51,6 +51,8 @@ module "ec2" {
   instance_profile_name = module.iam.instance_profile_name
   key_name              = var.key_name
   k3s_version           = var.k3s_version
+  ecr_registry          = split("/", module.ecr.repository_url)[0]
+  aws_region            = var.aws_region
 }
 
 module "ecr" {

--- a/infra/terraform/modules/ec2/main.tf
+++ b/infra/terraform/modules/ec2/main.tf
@@ -29,7 +29,13 @@ resource "aws_instance" "main" {
 
   user_data = templatefile("${path.module}/user_data.sh", {
     k3s_version = var.k3s_version
+    ecr_registry = var.ecr_registry
+    aws_region = var.aws_region
   })
 
-user_data_replace_on_change = true
+  user_data_replace_on_change = true
+
+  lifecycle {
+    ignore_changes = [ami]
+  }
 }

--- a/infra/terraform/modules/ec2/user_data.sh
+++ b/infra/terraform/modules/ec2/user_data.sh
@@ -6,9 +6,10 @@ exec > >(tee -a "$LOG") 2>&1
 
 echo "[$(date '+%Y-%m-%d %H:%M:%S')] user_data 시작"
 
-# ── 시스템 업데이트 ────────────────────────────────────────────
-echo "[$(date '+%Y-%m-%d %H:%M:%S')] 패키지 업데이트"
+# ── 시스템 업데이트 + git 설치 ────────────────────────────────────────────
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] 패키지 업데이트, git 설치"
 dnf update -y
+dnf install -y git
 
 # ── k3s 설치 ──────────────────────────────────────────────────
 K3S_VERSION="${k3s_version}"
@@ -24,7 +25,60 @@ echo "[$(date '+%Y-%m-%d %H:%M:%S')] k3s 서비스 상태 확인"
 systemctl enable k3s
 systemctl is-active k3s || { echo "[ERROR] k3s 서비스 시작 실패"; exit 1; }
 
-# ── kubeconfig 권한 설정 ──────────────────────────────────────
+# ── kubeconfig 전역 설정 ──────────────────────────────────────
 chmod 644 /etc/rancher/k3s/k3s.yaml
+echo 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml' > /etc/profile.d/k3s.sh
+
+# ── ECR 토큰 자동 갱신 스크립트 ──────────────────────────────
+cat > /usr/local/bin/refresh-ecr-token.sh << 'REFRESH_SCRIPT'
+#!/bin/bash
+set -euo pipefail
+ECR_REGISTRY="${ecr_registry}"
+AWS_REGION="${aws_region}"
+
+TOKEN=$(aws ecr get-login-password --region "$AWS_REGION")
+
+cat > /etc/rancher/k3s/registries.yaml << EOF
+mirrors:
+  "$ECR_REGISTRY":
+    endpoint:
+      - "https://$ECR_REGISTRY"
+configs:
+  "$ECR_REGISTRY":
+    auth:
+      username: AWS
+      password: "$TOKEN"
+EOF
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] ECR 토큰 갱신 완료"
+REFRESH_SCRIPT
+
+chmod +x /usr/local/bin/refresh-ecr-token.sh
+/usr/local/bin/refresh-ecr-token.sh
+
+# ── systemd timer: 6시간마다 자동 갱신 ───────────────────────
+cat > /etc/systemd/system/ecr-token-refresh.service << 'EOF'
+[Unit]
+Description=Refresh ECR authentication token
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/refresh-ecr-token.sh
+EOF
+
+cat > /etc/systemd/system/ecr-token-refresh.timer << 'EOF'
+[Unit]
+Description=ECR 토큰 6시간마다 자동 갱신
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=6h
+
+[Install]
+WantedBy=timers.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now ecr-token-refresh.timer
 
 echo "[$(date '+%Y-%m-%d %H:%M:%S')] user_data 완료"

--- a/infra/terraform/modules/ec2/variables.tf
+++ b/infra/terraform/modules/ec2/variables.tf
@@ -31,3 +31,13 @@ variable "k3s_version" {
   type        = string
   description = "설치할 k3s 버전 (예: v1.32.3+k3s1)"
 }
+
+variable "ecr_registry" {
+  type        = string
+  description = "ECR 레지스트리 URL (예: 123456789012.dkr.ecr.us-west-2.amazonaws.com)"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS 리전 (예: us-west-2)"
+}


### PR DESCRIPTION
## 문제

1. **AMI drift**: EC2 모듈이 `most_recent = true`로 최신 AMI를 동적 조회 중 → AWS가 새 AMI를 릴리즈하면 `terraform apply` 시 EC2 교체 발생 (Day 16에서 실제 발생한 장애)
2. **수동 초기 세팅 부담**: EC2 교체/신규 생성 시 git 설치, KUBECONFIG 설정, ECR 인증을 매번 수동으로 처리해야 했음
3. **ECR 토큰 12시간 만료**: 배포 전 수동 갱신 필요, 새벽 자동 배포 시 ImagePullBackOff 발생 위험

## 변경 내용

**`modules/ec2/main.tf`**
- `lifecycle { ignore_changes = [ami] }` 추가: 이후 AWS AMI 릴리즈가 있어도 Terraform이 교체를 시도하지 않음
- templatefile에 `ecr_registry`, `aws_region` 변수 전달

**`modules/ec2/variables.tf`**
- `ecr_registry`, `aws_region` 변수 추가

**`environments/dev/main.tf`**
- EC2 모듈에 `ecr_registry = split("/", module.ecr.repository_url)[0]` 전달

**`modules/ec2/user_data.sh`**
- `git` 설치 추가
- `/etc/profile.d/k3s.sh`로 KUBECONFIG 전역 설정 (모든 사용자/세션에서 자동 적용)
- ECR 토큰 갱신 스크립트 (`/usr/local/bin/refresh-ecr-token.sh`) 생성 + systemd timer로 6시간마다 자동 실행

## 검증 방법

- `terraform plan` 실행 시 AMI 변경으로 인한 `-/+` 교체 없음 확인
- 신규 EC2 기동 후 `git --version` 확인
- `echo $KUBECONFIG` → `/etc/rancher/k3s/k3s.yaml` 확인
- `systemctl status ecr-token-refresh.timer` → active 확인
- `/etc/rancher/k3s/registries.yaml` 내 ECR 인증 정보 자동 생성 확인

Closes #53 