### PR TITLE
django-prometheus 연동 및 /metrics 엔드포인트 추가하기

### DIFF
--- a/Disasterkok_backend/requirements.txt
+++ b/Disasterkok_backend/requirements.txt
@@ -33,3 +33,4 @@ typing_extensions==4.7.1
 tzdata==2023.3
 uritemplate==4.1.1
 urllib3==2.1.0
+django-prometheus==2.5.0

--- a/Disasterkok_backend/webapp/config/settings/base.py
+++ b/Disasterkok_backend/webapp/config/settings/base.py
@@ -60,6 +60,7 @@ PACKAGE_APPS = [
     'allauth.socialaccount',
     'allauth.socialaccount.providers.google',
     'channels',
+    'django_prometheus',
 ]
 
 PROJECT_APPS = [
@@ -72,6 +73,7 @@ PROJECT_APPS = [
 INSTALLED_APPS = DJANGO_APPS + PACKAGE_APPS + PROJECT_APPS
 
 MIDDLEWARE = [
+    'django_prometheus.middleware.PrometheusBeforeMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -81,6 +83,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'allauth.account.middleware.AccountMiddleware',
+    'django_prometheus.middleware.PrometheusAfterMiddleware',
 ]
 
 ROOT_URLCONF = 'config.urls'

--- a/Disasterkok_backend/webapp/config/urls.py
+++ b/Disasterkok_backend/webapp/config/urls.py
@@ -28,7 +28,7 @@ urlpatterns = [
     path('notifications/', include('notification.urls')),
     path('regions/', include('region.urls')),
     path('posts/', include('post.urls')),
-    path('metrics/', include('django_prometheus.urls')),
+    path('', include('django_prometheus.urls')),
 ]
 
 urlpatterns += [

--- a/Disasterkok_backend/webapp/config/urls.py
+++ b/Disasterkok_backend/webapp/config/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     path('notifications/', include('notification.urls')),
     path('regions/', include('region.urls')),
     path('posts/', include('post.urls')),
+    path('metrics/', include('django_prometheus.urls')),
 ]
 
 urlpatterns += [


### PR DESCRIPTION
## 📊 요약

Django 앱에 django-prometheus를 연동해 `/metrics` 엔드포인트를 노출한다. Prometheus + Grafana 모니터링 구축(#58, #59)의 선행 작업.

## 🚨 Breaking Change?

- [ ] 있음
- [x] 없음

## 🧾 PR 타입

- [x] ✨ 기능
- [ ] 🐛 버그
- [ ] ♻️ 리팩터
- [ ] 🔧 기타(빌드·CI·문서)

## ✅ 체크리스트

- [x] CI 통과 (lint, type, test)
- [ ] 테스트 코드 추가·수정
- [x] 문서/주석 업데이트
- [x] 개인정보 / 민감정보 제거

## 📚 상세

### 💬 추가 / 변경된 부분

- `requirements.txt`에 `django-prometheus==2.5.0` 추가
- `INSTALLED_APPS`, `MIDDLEWARE`에 `django_prometheus` 등록 (Before/After 미들웨어로 요청 처리 전체 구간 계측)
- `config/urls.py`에 `/metrics` 엔드포인트 노출

### 📣 리뷰 노트

로컬 테스트: `docker compose up --build -d` 후 `curl localhost/metrics` → Prometheus 텍스트 포맷 메트릭 응답 확인

## 🔗 관련 이슈

`Closes #57`